### PR TITLE
Updated .gitignore to GitHub Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-# Project exclude paths
-/.gradle/
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties


### PR DESCRIPTION
**GitHub** provides templates for .gitignore [files](https://github.com/github/gitignore/blob/master/Gradle.gitignore).
These files remove more unnecessary things.