### PR TITLE
Degradet Minecraft to Spigot Fork

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ version = "1.0.0"
 repositories {
     jcenter()
     mavenCentral()
-    maven(url = "https://papermc.io/repo/repository/maven-public/")
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.codemc.io/repository/maven-snapshots/")
 }
 
@@ -20,7 +20,7 @@ val minecraft_version: String by project
 
 dependencies {
     // PaperMC Dependency
-    compileOnly("com.destroystokyo.paper", "paper-api", "$minecraft_version-R0.1-SNAPSHOT") // Only used on compile time because we have a PaperMC Server so we don't need it in the final jar
+    compileOnly("org.spigotmc", "spigot-api", "$minecraft_version-R0.1-SNAPSHOT") // Only used on compile time because we have a PaperMC Server so we don't need it in the final jar
 
     // KSpigot dependency
     implementation("net.axay", "kspigot", "1.16.26")


### PR DESCRIPTION
Degraded to Spigot because Repository & [KSpigot](https://github.com/bluefireoly/KSpigot) tells, that it is based in [SpigotMC](https://hub.spigotmc.org/)