### PR TITLE
Deprecrated Repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,8 @@ group = "org.example"
 version = "1.0.0"
 
 repositories {
-    jcenter()
     mavenCentral()
-    maven(url = "https://papermc.io/repo/repository/maven-public/")
+    maven("https://papermc.io/repo/repository/maven-public/")
     maven("https://repo.codemc.io/repository/maven-snapshots/")
 }
 


### PR DESCRIPTION
jCenter got shut down in february 2021, use mavenCentral now!